### PR TITLE
Unused async/await pairs are removed to optimize and reduce compiled code

### DIFF
--- a/src/progaudi.tarantool/Box.cs
+++ b/src/progaudi.tarantool/Box.cs
@@ -21,9 +21,9 @@ namespace ProGaudi.Tarantool.Client
             Metrics = new Metrics(_logicalConnection);
         }
 
-        public async Task Connect()
+        public Task Connect()
         {
-            await _logicalConnection.Connect();
+            return _logicalConnection.Connect();
         }
 
         public static async Task<Box> Connect(string replicationSource)
@@ -69,15 +69,15 @@ namespace ProGaudi.Tarantool.Client
             return new Schema(_logicalConnection);
         }
 
-        public async Task Call_1_6(string functionName)
+        public Task Call_1_6(string functionName)
         {
-            await Call_1_6<TarantoolTuple, TarantoolTuple>(functionName, TarantoolTuple.Empty);
+            return Call_1_6<TarantoolTuple, TarantoolTuple>(functionName, TarantoolTuple.Empty);
         }
 
-        public async Task Call_1_6<TTuple>(string functionName, TTuple parameters)
+        public Task Call_1_6<TTuple>(string functionName, TTuple parameters)
             where TTuple : ITarantoolTuple
         {
-            await Call_1_6<TTuple, TarantoolTuple>(functionName, parameters);
+            return Call_1_6<TTuple, TarantoolTuple>(functionName, parameters);
         }
 
         public Task<DataResponse<TResponse[]>> Call_1_6<TResponse>(string functionName)
@@ -86,23 +86,23 @@ namespace ProGaudi.Tarantool.Client
             return Call_1_6<TarantoolTuple, TResponse>(functionName, TarantoolTuple.Empty);
         }
 
-        public async Task<DataResponse<TResponse[]>> Call_1_6<TTuple, TResponse>(string functionName, TTuple parameters)
+        public Task<DataResponse<TResponse[]>> Call_1_6<TTuple, TResponse>(string functionName, TTuple parameters)
             where TTuple : ITarantoolTuple
             where TResponse : ITarantoolTuple
         {
             var callRequest = new CallRequest<TTuple>(functionName, parameters, false);
-            return await _logicalConnection.SendRequest<CallRequest<TTuple>, TResponse>(callRequest);
+            return _logicalConnection.SendRequest<CallRequest<TTuple>, TResponse>(callRequest);
         }
 
-        public async Task Call(string functionName)
+        public Task Call(string functionName)
         {
-            await Call<TarantoolTuple, TarantoolTuple>(functionName, TarantoolTuple.Empty);
+            return Call<TarantoolTuple, TarantoolTuple>(functionName, TarantoolTuple.Empty);
         }
 
-        public async Task Call<TTuple>(string functionName, TTuple parameters)
+        public Task Call<TTuple>(string functionName, TTuple parameters)
             where TTuple : ITarantoolTuple
         {
-            await Call<TTuple, TarantoolTuple>(functionName, parameters);
+            return Call<TTuple, TarantoolTuple>(functionName, parameters);
         }
 
         public Task<DataResponse<TResponse[]>> Call<TResponse>(string functionName)
@@ -110,18 +110,18 @@ namespace ProGaudi.Tarantool.Client
             return Call<TarantoolTuple, TResponse>(functionName, TarantoolTuple.Empty);
         }
 
-        public async Task<DataResponse<TResponse[]>> Call<TTuple, TResponse>(string functionName, TTuple parameters)
+        public Task<DataResponse<TResponse[]>> Call<TTuple, TResponse>(string functionName, TTuple parameters)
             where TTuple : ITarantoolTuple
         {
             var callRequest = new CallRequest<TTuple>(functionName, parameters);
-            return await _logicalConnection.SendRequest<CallRequest<TTuple>, TResponse>(callRequest);
+            return _logicalConnection.SendRequest<CallRequest<TTuple>, TResponse>(callRequest);
         }
 
-        public async Task<DataResponse<TResponse[]>> Eval<TTuple, TResponse>(string expression, TTuple parameters)
+        public Task<DataResponse<TResponse[]>> Eval<TTuple, TResponse>(string expression, TTuple parameters)
            where TTuple : ITarantoolTuple
         {
             var evalRequest = new EvalRequest<TTuple>(expression, parameters);
-            return await _logicalConnection.SendRequest<EvalRequest<TTuple>, TResponse>(evalRequest);
+            return _logicalConnection.SendRequest<EvalRequest<TTuple>, TResponse>(evalRequest);
         }
 
         public Task<DataResponse<TResponse[]>> Eval<TResponse>(string expression)

--- a/src/progaudi.tarantool/Index.cs
+++ b/src/progaudi.tarantool/Index.cs
@@ -44,7 +44,7 @@ namespace ProGaudi.Tarantool.Client
             throw new NotImplementedException();
         }
 
-        public async Task<DataResponse<TTuple[]>> Select<TKey, TTuple>(TKey key, SelectOptions options = null)
+        public Task<DataResponse<TTuple[]>> Select<TKey, TTuple>(TKey key, SelectOptions options = null)
             where TKey : ITarantoolTuple
             where TTuple : ITarantoolTuple
         {
@@ -56,33 +56,33 @@ namespace ProGaudi.Tarantool.Client
                 options?.Iterator ?? Iterator.Eq,
                 key);
 
-            return await LogicalConnection.SendRequest<SelectRequest<TKey>, TTuple>(selectRequest);
+            return LogicalConnection.SendRequest<SelectRequest<TKey>, TTuple>(selectRequest);
         }
 
         ///Note: there is no such method in specification http://tarantool.org/doc/book/box/box_index.html.
         ///But common sense, and sources https://github.com/tarantool/tarantool/blob/1.7/src/box/lua/index.c says that that method sould be
-        public async Task<DataResponse<TTuple[]>> Insert<TTuple>(TTuple tuple)
+        public Task<DataResponse<TTuple[]>> Insert<TTuple>(TTuple tuple)
             where TTuple : ITarantoolTuple
         {
             var insertRequest = new InsertRequest<TTuple>(SpaceId, tuple);
 
-            return await LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(insertRequest);
+            return LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(insertRequest);
         }
 
         ///Note: there is no such method in specification http://tarantool.org/doc/book/box/box_index.html.
         ///But common sense, and sources https://github.com/tarantool/tarantool/blob/1.7/src/box/lua/index.c says that that method sould be
-        public async Task<DataResponse<TTuple[]>> Replace<TTuple>(TTuple tuple)
+        public Task<DataResponse<TTuple[]>> Replace<TTuple>(TTuple tuple)
             where TTuple : ITarantoolTuple
         {
             var replaceRequest = new ReplaceRequest<TTuple>(SpaceId, tuple);
 
-            return await LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(replaceRequest);
+            return LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(replaceRequest);
         }
 
-        public async Task<TTuple> Min<TTuple>()
+        public Task<TTuple> Min<TTuple>()
            where TTuple : ITarantoolTuple
         {
-            return await Min<TTuple, TarantoolTuple>(TarantoolTuple.Empty);
+            return Min<TTuple, TarantoolTuple>(TarantoolTuple.Empty);
         }
 
         public async Task<TTuple> Min<TTuple, TKey>(TKey key)
@@ -101,10 +101,10 @@ namespace ProGaudi.Tarantool.Client
             return minResponse.Data.SingleOrDefault();
         }
 
-        public async Task<TTuple> Max<TTuple>()
+        public Task<TTuple> Max<TTuple>()
             where TTuple : ITarantoolTuple
         {
-            return await Max<TTuple, TarantoolTuple>(TarantoolTuple.Empty);
+            return Max<TTuple, TarantoolTuple>(TarantoolTuple.Empty);
         }
 
         public async Task<TTuple> Max<TTuple, TKey>(TKey key = null)
@@ -135,7 +135,7 @@ namespace ProGaudi.Tarantool.Client
             throw new NotImplementedException();
         }
 
-        public async Task<DataResponse<TTuple[]>> Update<TTuple, TKey>(TKey key, UpdateOperation[] updateOperations)
+        public Task<DataResponse<TTuple[]>> Update<TTuple, TKey>(TKey key, UpdateOperation[] updateOperations)
             where TKey : ITarantoolTuple
             where TTuple : ITarantoolTuple
         {
@@ -145,10 +145,10 @@ namespace ProGaudi.Tarantool.Client
                 key,
                 updateOperations);
 
-            return await LogicalConnection.SendRequest<UpdateRequest<TKey>, TTuple>(updateRequest);
+            return LogicalConnection.SendRequest<UpdateRequest<TKey>, TTuple>(updateRequest);
         }
 
-        public async Task Upsert<TKey>(TKey key, UpdateOperation[] updateOperations)
+        public Task Upsert<TKey>(TKey key, UpdateOperation[] updateOperations)
             where TKey : ITarantoolTuple
         {
             var updateRequest = new UpsertRequest<TKey>(
@@ -156,16 +156,16 @@ namespace ProGaudi.Tarantool.Client
                 key,
                 updateOperations);
 
-            await LogicalConnection.SendRequestWithEmptyResponse(updateRequest);
+            return LogicalConnection.SendRequestWithEmptyResponse(updateRequest);
         }
 
-        public async Task<DataResponse<TTuple[]>> Delete<TKey, TTuple>(TKey key)
+        public Task<DataResponse<TTuple[]>> Delete<TKey, TTuple>(TKey key)
             where TKey : ITarantoolTuple
             where TTuple : ITarantoolTuple
         {
             var deleteRequest = new DeleteRequest<TKey>(SpaceId, Id, key);
 
-            return await LogicalConnection.SendRequest<DeleteRequest<TKey>, TTuple>(deleteRequest);
+            return LogicalConnection.SendRequest<DeleteRequest<TKey>, TTuple>(deleteRequest);
         }
 
         public Task Alter(IndexCreationOptions options)

--- a/src/progaudi.tarantool/LogicalConnection.cs
+++ b/src/progaudi.tarantool/LogicalConnection.cs
@@ -117,16 +117,16 @@ namespace ProGaudi.Tarantool.Client
             _clientOptions.LogWriter?.WriteLine($"Authentication request send: {authenticateRequest}");
         }
 
-        public async Task SendRequestWithEmptyResponse<TRequest>(TRequest request, TimeSpan? timeout = null)
+        public Task SendRequestWithEmptyResponse<TRequest>(TRequest request, TimeSpan? timeout = null)
             where TRequest : IRequest
         {
-            await SendRequestImpl<TRequest, EmptyResponse>(request, timeout);
+            return SendRequestImpl<TRequest, EmptyResponse>(request, timeout);
         }
 
-        public async Task<DataResponse<TResponse[]>> SendRequest<TRequest, TResponse>(TRequest request, TimeSpan? timeout = null)
+        public Task<DataResponse<TResponse[]>> SendRequest<TRequest, TResponse>(TRequest request, TimeSpan? timeout = null)
             where TRequest : IRequest
         {
-            return await SendRequestImpl<TRequest, DataResponse<TResponse[]>>(request, timeout);
+            return SendRequestImpl<TRequest, DataResponse<TResponse[]>>(request, timeout);
         }
 
         public static byte[] ReadFully(Stream input)

--- a/src/progaudi.tarantool/NetworkStreamPhysicalConnection.cs
+++ b/src/progaudi.tarantool/NetworkStreamPhysicalConnection.cs
@@ -53,16 +53,16 @@ namespace ProGaudi.Tarantool.Client
             _stream.Write(buffer, offset, count);
         }
 
-        public async Task Flush()
+        public Task Flush()
         {
             CheckConnectionStatus();
-            await _stream.FlushAsync();
+            return _stream.FlushAsync();
         }
 
-        public async Task<int> ReadAsync(byte[] buffer, int offset, int count)
+        public Task<int> ReadAsync(byte[] buffer, int offset, int count)
         {
             CheckConnectionStatus();
-            return await _stream.ReadAsync(buffer, offset, count);
+            return _stream.ReadAsync(buffer, offset, count);
         }
 
 #if PROGAUDI_NETCORE

--- a/src/progaudi.tarantool/Space.cs
+++ b/src/progaudi.tarantool/Space.cs
@@ -97,19 +97,19 @@ namespace ProGaudi.Tarantool.Client
             return result;
         }
 
-        public async Task<DataResponse<TTuple[]>> Insert<TTuple>(TTuple tuple)
+        public Task<DataResponse<TTuple[]>> Insert<TTuple>(TTuple tuple)
             where TTuple : ITarantoolTuple
         {
             var insertRequest = new InsertRequest<TTuple>(Id, tuple);
-            return await LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(insertRequest);
+            return LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(insertRequest);
         }
 
-        public async Task<DataResponse<TTuple[]>> Select<TKey, TTuple>(TKey selectKey)
+        public Task<DataResponse<TTuple[]>> Select<TKey, TTuple>(TKey selectKey)
           where TKey : ITarantoolTuple
           where TTuple : ITarantoolTuple
         {
             var selectRequest = new SelectRequest<TKey>(Id, PrimaryIndexId, uint.MaxValue, 0, Iterator.Eq, selectKey);
-            return await LogicalConnection.SendRequest<SelectRequest<TKey>, TTuple>(selectRequest);
+            return LogicalConnection.SendRequest<SelectRequest<TKey>, TTuple>(selectRequest);
         }
 
         public async Task<TTuple> Get<TKey, TTuple>(TKey key)
@@ -121,11 +121,11 @@ namespace ProGaudi.Tarantool.Client
             return response.Data.SingleOrDefault();
         }
 
-        public async Task<DataResponse<TTuple[]>> Replace<TTuple>(TTuple tuple)
+        public Task<DataResponse<TTuple[]>> Replace<TTuple>(TTuple tuple)
             where TTuple : ITarantoolTuple
         {
             var replaceRequest = new ReplaceRequest<TTuple>(Id, tuple);
-            return await LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(replaceRequest);
+            return LogicalConnection.SendRequest<InsertReplaceRequest<TTuple>, TTuple>(replaceRequest);
         }
 
         public async Task<T> Put<T>(T tuple)
@@ -135,27 +135,27 @@ namespace ProGaudi.Tarantool.Client
             return response.Data.First();
         }
 
-        public async Task<DataResponse<TTuple[]>> Update<TKey, TTuple>(TKey key, UpdateOperation[] updateOperations)
+        public Task<DataResponse<TTuple[]>> Update<TKey, TTuple>(TKey key, UpdateOperation[] updateOperations)
             where TKey : ITarantoolTuple
             where TTuple : ITarantoolTuple
         {
             var updateRequest = new UpdateRequest<TKey>(Id, PrimaryIndexId, key, updateOperations);
-            return await LogicalConnection.SendRequest<UpdateRequest<TKey>, TTuple>(updateRequest);
+            return LogicalConnection.SendRequest<UpdateRequest<TKey>, TTuple>(updateRequest);
         }
 
-        public async Task Upsert<TTuple>(TTuple tuple, UpdateOperation[] updateOperations)
+        public Task Upsert<TTuple>(TTuple tuple, UpdateOperation[] updateOperations)
          where TTuple : ITarantoolTuple
         {
             var upsertRequest = new UpsertRequest<TTuple>(Id, tuple, updateOperations);
-            await LogicalConnection.SendRequestWithEmptyResponse(upsertRequest);
+            return LogicalConnection.SendRequestWithEmptyResponse(upsertRequest);
         }
 
-        public async Task<DataResponse<TTuple[]>> Delete<TKey, TTuple>(TKey key)
+        public Task<DataResponse<TTuple[]>> Delete<TKey, TTuple>(TKey key)
            where TTuple : ITarantoolTuple
            where TKey : ITarantoolTuple
         {
             var deleteRequest = new DeleteRequest<TKey>(Id, PrimaryIndexId, key);
-            return await LogicalConnection.SendRequest<DeleteRequest<TKey>, TTuple>(deleteRequest);
+            return LogicalConnection.SendRequest<DeleteRequest<TKey>, TTuple>(deleteRequest);
         }
 
         public Task<uint> Count<TKey>(TKey key)


### PR DESCRIPTION
If some method can be written without await, then it should be written it without await, and remove the async keyword from the method. A non-async method returning Task is more efficient than an async method returning a value/void. Check here:
http://blog.stephencleary.com/2012/02/async-and-await.html

Simple async method:
		public async Task<int> UndirectTaskMethod()
		{
			return await Task.FromResult<int>(0);
		}
generate complex method based on state machine like this:
		[DebuggerStepThrough, AsyncStateMachine(typeof(AsyncClassObject.<UndirectTaskMethod>d__1))]
		public Task<int> UndirectTaskMethod()
		{
			AsyncClassObject.<UndirectTaskMethod>d__1 <UndirectTaskMethod>d__ = new AsyncClassObject.<UndirectTaskMethod>d__1();
			<UndirectTaskMethod>d__.<>4__this = this;
			<UndirectTaskMethod>d__.<>t__builder = AsyncTaskMethodBuilder<int>.Create();
			<UndirectTaskMethod>d__.<>1__state = -1;
			AsyncTaskMethodBuilder<int> <>t__builder = <UndirectTaskMethod>d__.<>t__builder;
			<>t__builder.Start<AsyncClassObject.<UndirectTaskMethod>d__1>(ref <UndirectTaskMethod>d__);
			return <UndirectTaskMethod>d__.<>t__builder.Task;
		}

